### PR TITLE
Code refacotring and adding new volume for Cortex

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,11 +70,11 @@ services:
     networks:
       mthc:
         ipv4_address: 172.16.0.9
-  
+
   cortex:
     image: thehiveproject/cortex:latest
     depends_on:
-      - elasticsearch 
+      - elasticsearch
     expose:
       - "9001"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     volumes:
       - ./conf/cortex.conf:/etc/cortex/application.conf
       - ./apps/Cortex-Analyzers:/opt/Cortex-Analyzers
+      - ./data/cortex/:/data
     environment:
       - VIRTUAL_HOST=cortex.ir.local
       - VIRTUAL_PORT=9001


### PR DESCRIPTION
To use some cortex analyzers, such as FireHOLBlocklists, MISPWarningLists, and VirusShare, a user must specify path to stored data. The pull request adds a new volume mapped to `/data` within the Cortex service to make it available for specifying external data.